### PR TITLE
feat: Add Byte struct, collect_skip_whitespace

### DIFF
--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -374,48 +374,6 @@ impl<const N: usize> Reader<N> {
         self.skip_whitespace();
         self.off == self.len
     }
-
-    /// Reads and collects `n` elements of type `T`, skipping any leading whitespace before each read.
-    pub fn collect_skip_whitespace<Cn: FromIterator<T>, T: Readable>(&mut self, n: usize) -> Cn {
-        Cn::from_iter((0..n).map(|_| {
-            self.skip_whitespace();
-            T::read(self)
-        }))
-    }
-    /// Reads and collects an `n`-by-`m` matrix of type `T`, skipping any leading whitespace before each read.
-    pub fn collect_2d_skip_whitespace<Cnm: FromIterator<Cm>, Cm: FromIterator<T>, T: Readable>(
-        &mut self,
-        n: usize,
-        m: usize,
-    ) -> Cnm {
-        Cnm::from_iter((0..n).map(|_| {
-            Cm::from_iter((0..m).map(|_| {
-                self.skip_whitespace();
-                T::read(self)
-            }))
-        }))
-    }
-    /// Reads and collects an `n`-by-`m`-by-`p` tensor of type `T`, skipping any leading whitespace before each read.
-    pub fn collect_3d_skip_whitespace<
-        Cnmp: FromIterator<Cmp>,
-        Cmp: FromIterator<Cp>,
-        Cp: FromIterator<T>,
-        T: Readable,
-    >(
-        &mut self,
-        n: usize,
-        m: usize,
-        p: usize,
-    ) -> Cnmp {
-        Cnmp::from_iter((0..n).map(|_| {
-            Cmp::from_iter((0..m).map(|_| {
-                Cp::from_iter((0..p).map(|_| {
-                    self.skip_whitespace();
-                    T::read(self)
-                }))
-            }))
-        }))
-    }
 }
 
 impl<const N: usize> ReaderTrait for Reader<N> {

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -21,7 +21,7 @@ pub trait ReaderTrait: Sized {
     fn u128(&mut self) -> u128;
     fn usize(&mut self) -> usize;
     fn f64(&mut self) -> f64;
-    fn ascii(&mut self) -> u8;
+    fn byte(&mut self) -> u8;
     fn word(&mut self) -> String;
     fn line(&mut self) -> String;
     fn skip_whitespace(&mut self) -> usize;
@@ -478,7 +478,7 @@ impl<const N: usize> ReaderTrait for Reader<N> {
             if let Ok(ans) = out { ans } else { f64::NAN }
         }
     }
-    fn ascii(&mut self) -> u8 {
+    fn byte(&mut self) -> u8 {
         self.try_refill(1);
         let mut out = 0u8;
         if self.off < self.len {

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -377,12 +377,10 @@ impl<const N: usize> Reader<N> {
 
     /// Reads and collects `n` elements of type `T`, skipping any leading whitespace before each read.
     pub fn collect_skip_whitespace<Cn: FromIterator<T>, T: Readable>(&mut self, n: usize) -> Cn {
-        Cn::from_iter(
-            (0..n).map(|_| {
-                self.skip_whitespace();
-                T::read(self)
-            })
-        )
+        Cn::from_iter((0..n).map(|_| {
+            self.skip_whitespace();
+            T::read(self)
+        }))
     }
     /// Reads and collects an `n`-by-`m` matrix of type `T`, skipping any leading whitespace before each read.
     pub fn collect_2d_skip_whitespace<Cnm: FromIterator<Cm>, Cm: FromIterator<T>, T: Readable>(
@@ -390,16 +388,12 @@ impl<const N: usize> Reader<N> {
         n: usize,
         m: usize,
     ) -> Cnm {
-        Cnm::from_iter(
-            (0..n).map(|_| {
-                Cm::from_iter(
-                    (0..m).map(|_| {
-                        self.skip_whitespace();
-                        T::read(self)
-                    })
-                )
-            })
-        )
+        Cnm::from_iter((0..n).map(|_| {
+            Cm::from_iter((0..m).map(|_| {
+                self.skip_whitespace();
+                T::read(self)
+            }))
+        }))
     }
     /// Reads and collects an `n`-by-`m`-by-`p` tensor of type `T`, skipping any leading whitespace before each read.
     pub fn collect_3d_skip_whitespace<
@@ -413,20 +407,14 @@ impl<const N: usize> Reader<N> {
         m: usize,
         p: usize,
     ) -> Cnmp {
-        Cnmp::from_iter(
-            (0..n).map(|_| {
-                Cmp::from_iter(
-                    (0..m).map(|_| {
-                        Cp::from_iter(
-                            (0..p).map(|_| {
-                                self.skip_whitespace();
-                                T::read(self)
-                            })
-                        )
-                    })
-                )
-            }),
-        )
+        Cnmp::from_iter((0..n).map(|_| {
+            Cmp::from_iter((0..m).map(|_| {
+                Cp::from_iter((0..p).map(|_| {
+                    self.skip_whitespace();
+                    T::read(self)
+                }))
+            }))
+        }))
     }
 }
 
@@ -556,7 +544,6 @@ impl<const N: usize> ReaderTrait for Reader<N> {
         }
         out
     }
-    
 }
 
 /*

--- a/basm-std/src/platform/io/reader_traits.rs
+++ b/basm-std/src/platform/io/reader_traits.rs
@@ -1,5 +1,6 @@
 use super::{Readable, ReaderTrait};
 use alloc::string::String;
+use core::ops::Deref;
 
 macro_rules! impl_primitive {
     ($($ty:ident)*) => {
@@ -30,12 +31,28 @@ impl Readable for Line {
     }
 }
 
+impl Deref for Line {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 pub struct Nonwhite(pub u8);
 
 impl Readable for Nonwhite {
     fn read(reader: &mut impl ReaderTrait) -> Self {
         reader.skip_whitespace();
         Self(reader.ascii())
+    }
+}
+
+impl Deref for Nonwhite {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/basm-std/src/platform/io/reader_traits.rs
+++ b/basm-std/src/platform/io/reader_traits.rs
@@ -30,10 +30,11 @@ impl Readable for Line {
     }
 }
 
-pub struct Byte(pub u8);
+pub struct Nonwhite(pub u8);
 
-impl Readable for Byte {
+impl Readable for Nonwhite {
     fn read(reader: &mut impl ReaderTrait) -> Self {
+        reader.skip_whitespace();
         Self(reader.ascii())
     }
 }

--- a/basm-std/src/platform/io/reader_traits.rs
+++ b/basm-std/src/platform/io/reader_traits.rs
@@ -44,7 +44,7 @@ pub struct Nonwhite(pub u8);
 impl Readable for Nonwhite {
     fn read(reader: &mut impl ReaderTrait) -> Self {
         reader.skip_whitespace();
-        Self(reader.ascii())
+        Self(reader.byte())
     }
 }
 

--- a/basm-std/src/platform/io/reader_traits.rs
+++ b/basm-std/src/platform/io/reader_traits.rs
@@ -30,6 +30,14 @@ impl Readable for Line {
     }
 }
 
+pub struct Byte(pub u8);
+
+impl Readable for Byte {
+    fn read(reader: &mut impl ReaderTrait) -> Self {
+        Self(reader.ascii())
+    }
+}
+
 impl<T: Readable, const N: usize> Readable for [T; N] {
     fn read(reader: &mut impl ReaderTrait) -> Self {
         core::array::from_fn(|_| T::read(reader))

--- a/tests/boj_14939.rs
+++ b/tests/boj_14939.rs
@@ -7,7 +7,7 @@ pub fn main() {
     for i in 0..n {
         for j in 0..n {
             reader.skip_whitespace();
-            let c = reader.ascii();
+            let c = reader.byte();
             if c == b'O' {
                 board[i] |= 1u32 << j;
             }


### PR DESCRIPTION
- Readable에 한 글자만 읽는 게 없어서 추가했습니다. (`Byte`)
- collect, collect_2d, collect_3d에 공백을 무시하는 버전을 추가했습니다.

이를 조합하면 다음 입력을...
```
2 3
abc
def
```
다음 코드로 입력받을 수 있습니다.
```rust
let n = reader.usize();
let m = reader.usize();
let board: Vec<Vec<Byte>> = reader.collect_2d_skip_whitespace(n, m);

writer.byte(board[0][1].0); // b
```