### PR TITLE
add geometry templates

### DIFF
--- a/basm-std/src/geometry.rs
+++ b/basm-std/src/geometry.rs
@@ -1,0 +1,69 @@
+
+use crate::utils::f64;
+use crate::utils::ToF64;
+pub mod point;
+use crate::geometry::point::Point;
+
+pub fn ccw<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> f64
+where
+    T: ToF64 + Copy,
+{
+    let a_x = a.x.to_f64();
+    let a_y = a.y.to_f64();
+    let b_x = b.x.to_f64();
+    let b_y = b.y.to_f64();
+    let c_x = c.x.to_f64();
+    let c_y = c.y.to_f64();
+
+    (b_x - a_x) * (c_y - a_y) - (b_y - a_y) * (c_x - a_x)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_point_equal_f64() {
+        let p1 = Point::<f64>::new(3.0, 5.0);
+        let p2 = Point::<f64>::new(3.0, 5.0);
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_point_equal_i128() {
+        let p1 = Point::<i128>::new(3, 5);
+        let p2 = Point::<i128>::new(3, 5);
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_ccw_counter_clockwise_f64() {
+        let a = Point::<f64>::new(0.0, 0.0);
+        let b = Point::<f64>::new(1.0, 0.0);
+        let c = Point::<f64>::new(1.0, 1.0);
+        assert!(ccw(a, b, c) > 0.0);
+    }
+
+    #[test]
+    fn test_ccw_clockwise_i128() {
+        let a = Point::<i128>::new(0, 0);
+        let b = Point::<i128>::new(1, 0);
+        let c = Point::<i128>::new(1, -1);
+        assert!(ccw(a, b, c) < 0.0);
+    }
+
+    #[test]
+    fn test_distance_f64() {
+        let p1 = Point::<f64>::new(0.0, 0.0);
+        let p2 = Point::<f64>::new(3.0, 4.0);
+        assert!((p1.dist(p2) - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_distance_i128() {
+        let p1 = Point::<i128>::new(0, 0);
+        let p2 = Point::<i128>::new(3, 4);
+        assert!((p1.dist(p2) - 5.0).abs() < 1e-9);
+    }
+}

--- a/basm-std/src/geometry.rs
+++ b/basm-std/src/geometry.rs
@@ -1,19 +1,19 @@
 
 use crate::utils::f64;
-use crate::utils::ToF64;
+use crate::utils::ToI128;
 pub mod point;
 use crate::geometry::point::Point;
 
-pub fn ccw<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> f64
+pub fn ccw<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> i128
 where
-    T: ToF64 + Copy,
+    T: ToI128 + Copy,
 {
-    let a_x = a.x.to_f64();
-    let a_y = a.y.to_f64();
-    let b_x = b.x.to_f64();
-    let b_y = b.y.to_f64();
-    let c_x = c.x.to_f64();
-    let c_y = c.y.to_f64();
+    let a_x = a.x.to_i128();
+    let a_y = a.y.to_i128();
+    let b_x = b.x.to_i128();
+    let b_y = b.y.to_i128();
+    let c_x = c.x.to_i128();
+    let c_y = c.y.to_i128();
 
     (b_x - a_x) * (c_y - a_y) - (b_y - a_y) * (c_x - a_x)
 }

--- a/basm-std/src/geometry/point.rs
+++ b/basm-std/src/geometry/point.rs
@@ -1,4 +1,4 @@
-use crate::utils::ToF64;
+use crate::utils::ToI128;
 use crate::utils::F64Ops;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -13,11 +13,11 @@ impl<T> Point<T> {
     }
 }
 
-impl<T: ToF64 + Copy> Point<T> {
-    pub fn dist(self, other: Point<T>) -> f64 {
-        let dx = self.x.to_f64() - other.x.to_f64();
-        let dy = self.y.to_f64() - other.y.to_f64();
-        (dx * dx + dy * dy).sqrt()
+impl<T: ToI128 + Copy> Point<T> {
+    pub fn dist(self, other: Point<T>) -> i128 {
+        let dx = self.x.to_i128() - other.x.to_i128();
+        let dy = self.y.to_i128() - other.y.to_i128();
+        dx*dx + dy*dy
     }
 }
 

--- a/basm-std/src/geometry/point.rs
+++ b/basm-std/src/geometry/point.rs
@@ -1,0 +1,29 @@
+use crate::utils::ToF64;
+use crate::utils::F64Ops;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point<T> {
+    pub x: T,
+    pub y: T,
+}
+
+impl<T> Point<T> {
+    pub fn new(x: T, y: T) -> Self {
+        Self { x, y }
+    }
+}
+
+impl<T: ToF64 + Copy> Point<T> {
+    pub fn dist(self, other: Point<T>) -> f64 {
+        let dx = self.x.to_f64() - other.x.to_f64();
+        let dy = self.y.to_f64() - other.y.to_f64();
+        (dx * dx + dy * dy).sqrt()
+    }
+}
+
+#[test]
+fn test_distance_i128() {
+    let p1 = Point::<i128>::new(0, 0);
+    let p2 = Point::<i128>::new(3, 4);
+    assert!((p1.dist(p2) - 5.0).abs() < 1e-9);
+}

--- a/basm-std/src/lib.rs
+++ b/basm-std/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(fn_align)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_array_assume_init)]
+#![feature(naked_functions)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(rustfmt, rustfmt_skip)] // temporary fix to keep compiler_builtins at the top to avoid linker errors
 
@@ -18,3 +19,4 @@ pub mod serialization;
 pub mod sorts;
 pub mod strings;
 pub mod utils;
+pub mod geometry;

--- a/basm-std/src/utils.rs
+++ b/basm-std/src/utils.rs
@@ -1,67 +1,47 @@
 pub mod f64;
 pub use f64::*;
 
-pub trait ToF64 {
-    fn to_f64(self) -> f64;
+pub trait ToI128 {
+    fn to_i128(self) -> i128;
 }
 
-impl ToF64 for f64 {
-    fn to_f64(self) -> f64 {
-        self
+impl ToI128 for i128 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-impl ToF64 for i128 {
-    fn to_f64(self) -> f64 {
-        self as f64
+impl ToI128 for usize {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-impl ToF64 for i64 {
-    fn to_f64(self) -> f64 {
-        self as f64
+impl ToI128 for f32 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-impl ToF64 for i32 {
-    fn to_f64(self) -> f64 {
-        self as f64
+impl ToI128 for f64 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-impl ToF64 for u64 {
-    fn to_f64(self) -> f64 {
-        self as f64
+impl ToI128 for i32 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-impl ToF64 for usize {
-    fn to_f64(self) -> f64 {
-        self as f64
+impl ToI128 for i64 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_to_f64_from_f64() {
-        let x: f64 = 3.1415;
-        assert!((x.to_f64() - 3.1415).abs() < 1e-10);
+impl ToI128 for i16 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
-
-    #[test]
-    fn test_to_f64_from_i128() {
-        let x: i128 = 42;
-        assert!((x.to_f64() - 42.0).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_to_f64_large_i128() {
-        let x: i128 = 1_000_000_000_000_000_000;
-        let y = x.to_f64();
-        assert!((y - 1e18).abs() < 1e3);
+}
+impl ToI128 for i8 {
+    fn to_i128(self) -> i128 {
+        return self as i128;
     }
 }

--- a/basm-std/src/utils.rs
+++ b/basm-std/src/utils.rs
@@ -1,2 +1,67 @@
 pub mod f64;
 pub use f64::*;
+
+pub trait ToF64 {
+    fn to_f64(self) -> f64;
+}
+
+impl ToF64 for f64 {
+    fn to_f64(self) -> f64 {
+        self
+    }
+}
+
+impl ToF64 for i128 {
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+impl ToF64 for i64 {
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+impl ToF64 for i32 {
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+impl ToF64 for u64 {
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+impl ToF64 for usize {
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_f64_from_f64() {
+        let x: f64 = 3.1415;
+        assert!((x.to_f64() - 3.1415).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_to_f64_from_i128() {
+        let x: i128 = 42;
+        assert!((x.to_f64() - 42.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_to_f64_large_i128() {
+        let x: i128 = 1_000_000_000_000_000_000;
+        let y = x.to_f64();
+        assert!((y - 1e18).abs() < 1e3);
+    }
+}

--- a/basm/src/solution.rs
+++ b/basm/src/solution.rs
@@ -3,19 +3,19 @@ use basm::geometry::{point,ccw};
 pub fn main() {
     let mut reader: Reader = Default::default();
     let mut writer: Writer = Default::default();
-    let a = reader.i128();
-    let b = reader.i128();
-    let c = reader.i128();
-    let d = reader.i128();
-    let e = reader.i128();
-    let f = reader.i128();
+    let a = reader.i32();
+    let b = reader.i32();
+    let c = reader.i32();
+    let d = reader.i32();
+    let e = reader.i32();
+    let f = reader.i32();
     let p1 = point::Point::new(a,b);
     let p2 = point::Point::new(c,d);
     let p3 = point::Point::new(e,f);
     let res = ccw(p1,p2,p3);
-    if res < 0.0 {
+    if res < 0 {
         writer.str("-1");
-    } else if res>0.0 {
+    } else if res>0 {
         writer.str("1");
     } else {
         writer.str("0");

--- a/basm/src/solution.rs
+++ b/basm/src/solution.rs
@@ -1,8 +1,23 @@
 use basm::platform::io::{Print, Reader, ReaderTrait, Writer};
+use basm::geometry::{point,ccw};
 pub fn main() {
     let mut reader: Reader = Default::default();
     let mut writer: Writer = Default::default();
-    let a = reader.i64();
-    let b = reader.i64();
-    writer.println(a + b);
+    let a = reader.i128();
+    let b = reader.i128();
+    let c = reader.i128();
+    let d = reader.i128();
+    let e = reader.i128();
+    let f = reader.i128();
+    let p1 = point::Point::new(a,b);
+    let p2 = point::Point::new(c,d);
+    let p3 = point::Point::new(e,f);
+    let res = ccw(p1,p2,p3);
+    if res < 0.0 {
+        writer.str("-1");
+    } else if res>0.0 {
+        writer.str("1");
+    } else {
+        writer.str("0");
+    }
 }


### PR DESCRIPTION
basm에 geometry가 없더라고요. 그래서 추가 했습니다! 

- ccw로 평면 위에 놓여진 세 점의 방향관계를 구할 수 있습니다.

- dist 함수로 점과 점의 거리를 구할 수 있습니다.

아래는 ccw의 예제입니다.
이 코드로 11758 - CCW 문제를 풀 수 있습니다.

```rust
use basm::geometry::{point,ccw};
pub fn main() {
    let mut reader: Reader = Default::default();
    let mut writer: Writer = Default::default();
    let a = reader.i32();
    let b = reader.i32();
    let c = reader.i32();
    let d = reader.i32();
    let e = reader.i32();
    let f = reader.i32();
    let p1 = point::Point::new(a,b);
    let p2 = point::Point::new(c,d);
    let p3 = point::Point::new(e,f);
    let res = ccw(p1,p2,p3);
    if res < 0 {
        writer.str("-1");
    } else if res>0 {
        writer.str("1");
    } else {
        writer.str("0");
    }
}
```
