### PR TITLE
Add MmapReader

### DIFF
--- a/basm-std/src/platform/io/mod.rs
+++ b/basm-std/src/platform/io/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(all(target_arch = "x86_64", not(test)))]
+pub use reader::MmapReader;
 mod reader;
 pub use reader::{Readable, Reader, ReaderTrait};
 mod writer;

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -7,7 +7,119 @@ pub trait Readable {
     fn read(reader: &mut impl ReaderTrait) -> Self;
 }
 
+mod position {
+    #[cfg_attr(
+        any(target_arch = "x86_64", target_arch = "x86"),
+        target_feature(enable = "avx2")
+    )]
+    pub unsafe fn white(s: &[u8]) -> Option<usize> {
+        s.iter().position(|&c| c <= b' ')
+    }
+    #[cfg_attr(
+        any(target_arch = "x86_64", target_arch = "x86"),
+        target_feature(enable = "avx2")
+    )]
+    pub unsafe fn newline(s: &[u8]) -> Option<usize> {
+        s.iter().position(|&c| c == b'\n')
+    }
+    #[cfg_attr(
+        any(target_arch = "x86_64", target_arch = "x86"),
+        target_feature(enable = "avx2,sse4.2")
+    )]
+    pub unsafe fn memchr(s: &[u8], delim: u8) -> Option<usize> {
+        s.iter().position(|&b| b == delim)
+    }
+}
+
+/// Note: _internal prefix solely for avoiding name clash with public method
+trait ReaderBufferTrait: Sized {
+    fn try_refill_internal(&mut self, readahead: usize) -> usize;
+    fn remain_internal(&self) -> &[u8];
+    fn advance(&mut self, bytes: usize); // raw functionality (cf. try_consume: has sanity checks)
+
+    #[cfg(any(not(feature = "short"), feature = "fastio"))]
+    fn noskip_u64(&mut self) -> u64 {
+        const POW10: [u32; 9] = [
+            1,
+            10,
+            100,
+            1_000,
+            10_000,
+            100_000,
+            1_000_000,
+            10_000_000,
+            100_000_000,
+        ];
+        let mut out = 0;
+        loop {
+            let mut c = unsafe {
+                self.remain_internal()
+                    .as_ptr()
+                    .cast::<u64>()
+                    .read_unaligned()
+            };
+            let m = !c & 0x1010101010101010;
+            let len = m.trailing_zeros() >> 3;
+            if len == 0 {
+                break out;
+            }
+            self.advance(len as usize);
+            out *= POW10[len as usize] as u64;
+            c <<= (8 - len) << 3;
+            c = (c & 0x0F0F0F0F0F0F0F0F).wrapping_mul(2561) >> 8;
+            c = (c & 0x00FF00FF00FF00FF).wrapping_mul(6553601) >> 16;
+            c = (c & 0x0000FFFF0000FFFF).wrapping_mul(42949672960001) >> 32;
+            out += c;
+        }
+    }
+    #[cfg(all(feature = "short", not(feature = "fastio")))]
+    fn noskip_u64(&mut self) -> u64 {
+        let mut n = 0;
+        'outer: loop {
+            let data = self.remain();
+            for i in 0..data.len() {
+                let b = data[i];
+                if b > 32 {
+                    n *= 10;
+                    n += b as u64 & 0x0F;
+                } else {
+                    self.advance(i);
+                    break 'outer n;
+                }
+            }
+            self.advance(data.len());
+        }
+    }
+    fn noskip_u128(&mut self) -> u128 {
+        let mut n = 0;
+        'outer: loop {
+            let data = self.remain();
+            for (i, &b) in data.iter().enumerate() {
+                if b > 32 {
+                    n *= 10;
+                    n += b as u128 & 0x0F;
+                } else {
+                    self.advance(i);
+                    break 'outer n;
+                }
+            }
+            self.advance(data.len());
+        }
+    }
+}
+
 pub trait ReaderTrait: Sized {
+    fn try_refill(&mut self, readahead: usize) -> usize;
+    fn try_consume(&mut self, bytes: usize) -> usize;
+    fn remain(&self) -> &[u8];
+    fn skip_until_whitespace(&mut self) -> usize;
+    fn until(&mut self, delim: u8, buf: &mut String) -> usize;
+    fn discard(&mut self, until: u8) -> usize;
+    fn word_buf(&mut self, buf: &mut [u8]) -> usize;
+    fn word_to_string(&mut self, buf: &mut String);
+    fn line_to_string(&mut self, buf: &mut String);
+    fn is_eof(&mut self) -> bool;
+    fn is_eof_skip_whitespace(&mut self) -> bool;
     fn i8(&mut self) -> i8;
     fn i16(&mut self) -> i16;
     fn i32(&mut self) -> i32;
@@ -63,6 +175,315 @@ pub trait ReaderTrait: Sized {
     }
 }
 
+impl<T: ReaderBufferTrait> ReaderTrait for T {
+    fn try_refill(&mut self, readahead: usize) -> usize {
+        self.try_refill_internal(readahead)
+    }
+    fn try_consume(&mut self, bytes: usize) -> usize {
+        let mut consumed = 0;
+        while consumed < bytes {
+            let data = self.remain();
+            let len = data.len();
+            if data.is_empty() && self.try_refill(1) == 0 {
+                break;
+            }
+            let delta = core::cmp::min(len, bytes - consumed);
+            self.advance(delta);
+            consumed += delta;
+        }
+        consumed
+    }
+    fn remain(&self) -> &[u8] {
+        self.remain_internal()
+    }
+    fn skip_until_whitespace(&mut self) -> usize {
+        let mut total = 0;
+        'outer: loop {
+            let data = self.remain();
+            for (i, &b) in data.iter().enumerate() {
+                if b <= b' ' {
+                    total += i;
+                    self.advance(i);
+                    break 'outer total;
+                }
+            }
+            self.advance(data.len());
+            if self.try_refill(1) == 0 {
+                break total;
+            }
+        }
+    }
+    fn until(&mut self, delim: u8, buf: &mut String) -> usize {
+        let mut total = 0;
+        loop {
+            let range = self.remain();
+            let len = range.len();
+            if let Some(i) = unsafe { position::memchr(range, delim) } {
+                unsafe { buf.as_mut_vec() }.extend_from_slice(&range[..i]);
+                self.advance(i + 1);
+                break total + i;
+            } else {
+                unsafe { buf.as_mut_vec() }.extend_from_slice(range);
+                self.advance(len);
+                total += len;
+                if self.try_refill(1) == 0 {
+                    break total;
+                }
+            }
+        }
+    }
+    fn discard(&mut self, until: u8) -> usize {
+        let mut total = 0;
+        loop {
+            let range = self.remain();
+            let len = range.len();
+            let pos = unsafe { position::memchr(range, until) };
+            if let Some(pos) = pos {
+                total += pos;
+                self.advance(pos + 1);
+                break total;
+            }
+            total += len;
+            self.advance(len);
+            if self.try_refill(1) == 0 {
+                break total;
+            }
+        }
+    }
+
+    fn word_buf(&mut self, buf: &mut [u8]) -> usize {
+        self.skip_whitespace();
+        let mut total = 0;
+        while total < buf.len() {
+            let range = self.remain();
+            let len = range.len();
+            if len == 0 {
+                // no more data available
+                break;
+            }
+
+            let rem = core::cmp::min(len, buf.len() - total);
+            let data = &range[..rem];
+            if let Some(pos) = unsafe { position::white(data) } {
+                buf[len..len + pos].copy_from_slice(&data[..pos]);
+                total += pos;
+                self.advance(pos);
+                break;
+            } else {
+                buf[len..len + rem].copy_from_slice(data);
+                total += rem;
+                self.advance(rem);
+                self.try_refill(1);
+            }
+        }
+        total
+    }
+    fn word_to_string(&mut self, buf: &mut String) {
+        self.skip_whitespace();
+        loop {
+            let data = self.remain();
+            let len = data.len();
+            if len == 0 {
+                // no more data available
+                break;
+            }
+
+            if let Some(pos) = unsafe { position::white(data) } {
+                unsafe { buf.as_mut_vec() }.extend_from_slice(&data[..pos]);
+                self.advance(pos);
+                break;
+            } else {
+                unsafe { buf.as_mut_vec() }.extend_from_slice(data);
+                self.advance(len);
+                self.try_refill(1);
+            }
+        }
+    }
+    fn line_to_string(&mut self, buf: &mut String) {
+        self.try_refill(1);
+        loop {
+            let data = self.remain();
+            let len = data.len();
+            if len == 0 {
+                // no more data available
+                break;
+            }
+
+            if let Some(pos) = unsafe { position::newline(data) } {
+                let pos_out = if pos > 0 && data[pos - 1] == b'\r' {
+                    pos - 1
+                } else {
+                    pos
+                };
+                unsafe { buf.as_mut_vec() }.extend_from_slice(&data[..pos_out]);
+                self.advance(pos + 1);
+                break;
+            } else {
+                unsafe { buf.as_mut_vec() }.extend_from_slice(data);
+                self.advance(len);
+                self.try_refill(1);
+            }
+        }
+    }
+    fn is_eof(&mut self) -> bool {
+        let mut range = self.remain();
+        if range.is_empty() {
+            self.try_refill(1);
+            range = self.remain();
+        }
+        range.is_empty()
+    }
+    fn is_eof_skip_whitespace(&mut self) -> bool {
+        self.skip_whitespace();
+        self.remain().is_empty()
+    }
+    fn word(&mut self) -> String {
+        let mut buf = String::new();
+        self.word_to_string(&mut buf);
+        buf
+    }
+    fn line(&mut self) -> String {
+        let mut buf = String::new();
+        self.line_to_string(&mut buf);
+        buf
+    }
+    fn i8(&mut self) -> i8 {
+        self.i32() as i8
+    }
+    fn u8(&mut self) -> u8 {
+        self.u32() as u8
+    }
+    fn i16(&mut self) -> i16 {
+        self.i32() as i16
+    }
+    fn u16(&mut self) -> u16 {
+        self.u32() as u16
+    }
+    fn i32(&mut self) -> i32 {
+        self.skip_whitespace();
+        self.try_refill(17);
+        let sign = self.remain()[0] == b'-';
+        (if sign {
+            self.advance(1);
+            self.noskip_u64().wrapping_neg()
+        } else {
+            self.noskip_u64()
+        }) as i32
+    }
+    fn u32(&mut self) -> u32 {
+        self.skip_whitespace();
+        self.try_refill(16);
+        self.noskip_u64() as u32
+    }
+    fn i64(&mut self) -> i64 {
+        self.skip_whitespace();
+        self.try_refill(25);
+        let sign = self.remain()[0] == b'-';
+        (if sign {
+            self.advance(1);
+            self.noskip_u64().wrapping_neg()
+        } else {
+            self.noskip_u64()
+        }) as i64
+    }
+    fn u64(&mut self) -> u64 {
+        self.skip_whitespace();
+        self.try_refill(24);
+        self.noskip_u64()
+    }
+    fn i128(&mut self) -> i128 {
+        self.skip_whitespace();
+        self.try_refill(41);
+        let sign = self.remain()[0] == b'-';
+        (if sign {
+            self.advance(1);
+            self.noskip_u128().wrapping_neg()
+        } else {
+            self.noskip_u128()
+        }) as i128
+    }
+    fn u128(&mut self) -> u128 {
+        self.skip_whitespace();
+        self.try_refill(40);
+        self.noskip_u128()
+    }
+    #[cfg(target_pointer_width = "32")]
+    fn isize(&mut self) -> isize {
+        self.i32() as isize
+    }
+    #[cfg(target_pointer_width = "32")]
+    fn usize(&mut self) -> usize {
+        self.u32() as usize
+    }
+    #[cfg(target_pointer_width = "64")]
+    fn isize(&mut self) -> isize {
+        self.i64() as isize
+    }
+    #[cfg(target_pointer_width = "64")]
+    fn usize(&mut self) -> usize {
+        self.u64() as usize
+    }
+    #[cfg(all(not(target_pointer_width = "32"), not(target_pointer_width = "64")))]
+    fn isize(&mut self) -> isize {
+        self.i128() as isize
+    }
+    #[cfg(all(not(target_pointer_width = "32"), not(target_pointer_width = "64")))]
+    fn usize(&mut self) -> usize {
+        self.u128() as usize
+    }
+    fn f64(&mut self) -> f64 {
+        /* For simplicity, we assume the input string is at most 64 bytes.
+         * Strings longer than this length are either incorrectly parsed
+         * (scientific notations get their exponents truncated) or approximately parsed
+         * (decimal notations get their tails truncated yielding approximately
+         * correct outputs). */
+        self.skip_whitespace();
+        self.try_refill(64);
+        let data = self.remain();
+        let mut end = 0;
+        while end < data.len() && data[end] > b' ' {
+            end += 1;
+        }
+        if end == 0 {
+            f64::NAN
+        } else {
+            let s = unsafe { core::str::from_utf8_unchecked(&data[..end]) };
+            let out = f64::from_str(s);
+            self.skip_until_whitespace();
+            if let Ok(ans) = out { ans } else { f64::NAN }
+        }
+    }
+    fn byte(&mut self) -> u8 {
+        self.try_refill(1);
+        let mut out = 0u8;
+        let data = self.remain();
+        if !data.is_empty() {
+            out = data[0];
+            self.advance(1);
+        }
+        out
+    }
+    // We do not use avx2 for this function since most of the time
+    // we only skip a few whitespaces.
+    fn skip_whitespace(&mut self) -> usize {
+        let mut total = 0;
+        'outer: loop {
+            let data = self.remain();
+            for (i, &b) in data.iter().enumerate() {
+                if b > b' ' {
+                    self.advance(i);
+                    break 'outer total;
+                }
+                total += 1;
+            }
+            self.advance(data.len());
+            if self.try_refill(1) == 0 {
+                break total;
+            }
+        }
+    }
+}
+
 pub struct Reader<const N: usize = { super::DEFAULT_BUF_SIZE }> {
     buf: [MaybeUninit<u8>; N],
     len: usize,
@@ -72,30 +493,6 @@ pub struct Reader<const N: usize = { super::DEFAULT_BUF_SIZE }> {
 impl<const N: usize> Default for Reader<N> {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-mod position {
-    #[cfg_attr(
-        any(target_arch = "x86_64", target_arch = "x86"),
-        target_feature(enable = "avx2")
-    )]
-    pub unsafe fn white(s: &[u8]) -> Option<usize> {
-        s.iter().position(|&c| c <= b' ')
-    }
-    #[cfg_attr(
-        any(target_arch = "x86_64", target_arch = "x86"),
-        target_feature(enable = "avx2")
-    )]
-    pub unsafe fn newline(s: &[u8]) -> Option<usize> {
-        s.iter().position(|&c| c == b'\n')
-    }
-    #[cfg_attr(
-        any(target_arch = "x86_64", target_arch = "x86"),
-        target_feature(enable = "avx2,sse4.2")
-    )]
-    pub unsafe fn memchr(s: &[u8], delim: u8) -> Option<usize> {
-        s.iter().position(|&b| b == delim)
     }
 }
 
@@ -114,7 +511,10 @@ impl<const N: usize> Reader<N> {
             off: 0,
         }
     }
-    pub fn try_refill(&mut self, readahead: usize) -> usize {
+}
+
+impl<const N: usize> ReaderBufferTrait for Reader<N> {
+    fn try_refill_internal(&mut self, readahead: usize) -> usize {
         /* readahead cannot exceed the buffer size */
         assert!(readahead <= Self::BUF_LEN);
         unsafe {
@@ -160,344 +560,11 @@ impl<const N: usize> Reader<N> {
             rem
         }
     }
-    pub fn try_consume(&mut self, bytes: usize) -> usize {
-        let mut consumed = 0;
-        while consumed < bytes {
-            if self.off == self.len && self.try_refill(1) == 0 {
-                break;
-            }
-            let delta = core::cmp::min(self.len - self.off, bytes - consumed);
-            self.off += delta;
-            consumed += delta;
-        }
-        consumed
-    }
-
-    pub fn skip_until_whitespace(&mut self) -> usize {
-        let mut len = 0;
-        'outer: loop {
-            while self.off < self.len {
-                if unsafe { self.buf[self.off].assume_init() } <= b' ' {
-                    break 'outer len;
-                }
-                self.off += 1;
-                len += 1;
-            }
-            if self.try_refill(1) == 0 {
-                break len;
-            }
-        }
-    }
-    pub fn until(&mut self, delim: u8, buf: &mut String) -> usize {
-        let mut total = 0;
-        loop {
-            let len = self.len - self.off;
-            let range = unsafe { self.buf[self.off..self.off + len].assume_init_ref() };
-            if let Some(i) = unsafe { position::memchr(range, delim) } {
-                unsafe { buf.as_mut_vec() }.extend_from_slice(&range[..i]);
-                self.off += i + 1;
-                break total + i;
-            } else {
-                unsafe { buf.as_mut_vec() }.extend_from_slice(range);
-                self.off = self.len;
-                total += len;
-                if self.try_refill(1) == 0 {
-                    break total;
-                }
-            }
-        }
-    }
-    pub fn remain(&self) -> &[u8] {
+    fn remain_internal(&self) -> &[u8] {
         unsafe { self.buf[self.off..self.len].assume_init_ref() }
     }
-    pub fn discard(&mut self, until: u8) -> usize {
-        let mut len = 0;
-        loop {
-            let pos = unsafe { position::memchr(self.remain(), until) };
-            if let Some(pos) = pos {
-                len += pos;
-                self.off += pos + 1;
-                break len;
-            }
-            len += self.len - self.off;
-            self.off = self.len;
-            if self.try_refill(1) == 0 {
-                break len;
-            }
-        }
-    }
-
-    pub fn word_buf(&mut self, buf: &mut [u8]) -> usize {
-        self.skip_whitespace();
-        let mut len = 0;
-        while self.off < self.len && len < buf.len() {
-            let rem = core::cmp::min(self.len - self.off, buf.len() - len);
-            let data = &self.remain()[..rem];
-            if let Some(pos) = unsafe { position::white(data) } {
-                buf[len..len + pos].copy_from_slice(&data[..pos]);
-                len += pos;
-                self.off += pos;
-                break;
-            } else {
-                buf[len..len + rem].copy_from_slice(data);
-                len += rem;
-                self.off += rem;
-                self.try_refill(1);
-            }
-        }
-        len
-    }
-    pub fn word_to_string(&mut self, buf: &mut String) {
-        self.skip_whitespace();
-        while self.off < self.len {
-            let rem = self.len - self.off;
-            let data = &self.remain()[..rem];
-            if let Some(pos) = unsafe { position::white(data) } {
-                unsafe { buf.as_mut_vec() }.extend_from_slice(&data[..pos]);
-                self.off += pos;
-                break;
-            } else {
-                unsafe { buf.as_mut_vec() }.extend_from_slice(data);
-                self.off += rem;
-                self.try_refill(1);
-            }
-        }
-    }
-    pub fn line_to_string(&mut self, buf: &mut String) {
-        self.try_refill(1);
-        while self.off < self.len {
-            let rem = self.len - self.off;
-            let data = &self.remain()[..rem];
-            if let Some(pos) = unsafe { position::newline(data) } {
-                let pos_out = if pos > 0 && data[pos - 1] == b'\r' {
-                    pos - 1
-                } else {
-                    pos
-                };
-                unsafe { buf.as_mut_vec() }.extend_from_slice(&data[..pos_out]);
-                self.off += pos + 1;
-                break;
-            } else {
-                unsafe { buf.as_mut_vec() }.extend_from_slice(data);
-                self.off += rem;
-                self.try_refill(1);
-            }
-        }
-    }
-
-    #[cfg(any(not(feature = "short"), feature = "fastio"))]
-    fn noskip_u64(&mut self) -> u64 {
-        const POW10: [u32; 9] = [
-            1,
-            10,
-            100,
-            1_000,
-            10_000,
-            100_000,
-            1_000_000,
-            10_000_000,
-            100_000_000,
-        ];
-        let mut out = 0;
-        loop {
-            let mut c = unsafe { self.buf[self.off..].as_ptr().cast::<u64>().read_unaligned() };
-            let m = !c & 0x1010101010101010;
-            let len = m.trailing_zeros() >> 3;
-            if len == 0 {
-                break out;
-            }
-            self.off += len as usize;
-            out *= POW10[len as usize] as u64;
-            c <<= (8 - len) << 3;
-            c = (c & 0x0F0F0F0F0F0F0F0F).wrapping_mul(2561) >> 8;
-            c = (c & 0x00FF00FF00FF00FF).wrapping_mul(6553601) >> 16;
-            c = (c & 0x0000FFFF0000FFFF).wrapping_mul(42949672960001) >> 32;
-            out += c;
-        }
-    }
-    #[cfg(all(feature = "short", not(feature = "fastio")))]
-    fn noskip_u64(&mut self) -> u64 {
-        let mut n = 0;
-        loop {
-            let b = unsafe { self.buf[self.off].assume_init() };
-            if b > 32 {
-                n *= 10;
-                n += (b - b'0') as u64;
-                self.off += 1;
-            } else {
-                break n;
-            }
-        }
-    }
-    fn noskip_u128(&mut self) -> u128 {
-        let mut n = 0;
-        while self.off < self.len {
-            let b = unsafe { self.buf[self.off].assume_init() };
-            if b > 32 {
-                n *= 10;
-                n += b as u128 & 0x0F;
-                self.off += 1;
-            } else {
-                break;
-            }
-        }
-        n
-    }
-
-    pub fn is_eof(&mut self) -> bool {
-        if self.off == self.len {
-            self.try_refill(1);
-        }
-        self.off == self.len
-    }
-    pub fn is_eof_skip_whitespace(&mut self) -> bool {
-        self.skip_whitespace();
-        self.off == self.len
-    }
-}
-
-impl<const N: usize> ReaderTrait for Reader<N> {
-    fn word(&mut self) -> String {
-        let mut buf = String::new();
-        self.word_to_string(&mut buf);
-        buf
-    }
-    fn line(&mut self) -> String {
-        let mut buf = String::new();
-        self.line_to_string(&mut buf);
-        buf
-    }
-    fn i8(&mut self) -> i8 {
-        self.i32() as i8
-    }
-    fn u8(&mut self) -> u8 {
-        self.u32() as u8
-    }
-    fn i16(&mut self) -> i16 {
-        self.i32() as i16
-    }
-    fn u16(&mut self) -> u16 {
-        self.u32() as u16
-    }
-    fn i32(&mut self) -> i32 {
-        self.skip_whitespace();
-        self.try_refill(17);
-        let sign = unsafe { self.buf[self.off].assume_init() } == b'-';
-        (if sign {
-            self.off += 1;
-            self.noskip_u64().wrapping_neg()
-        } else {
-            self.noskip_u64()
-        }) as i32
-    }
-    fn u32(&mut self) -> u32 {
-        self.skip_whitespace();
-        self.try_refill(16);
-        self.noskip_u64() as u32
-    }
-    fn i64(&mut self) -> i64 {
-        self.skip_whitespace();
-        self.try_refill(25);
-        let sign = unsafe { self.buf[self.off].assume_init() } == b'-';
-        (if sign {
-            self.off += 1;
-            self.noskip_u64().wrapping_neg()
-        } else {
-            self.noskip_u64()
-        }) as i64
-    }
-    fn u64(&mut self) -> u64 {
-        self.skip_whitespace();
-        self.try_refill(24);
-        self.noskip_u64()
-    }
-    fn i128(&mut self) -> i128 {
-        self.skip_whitespace();
-        self.try_refill(41);
-        let sign = unsafe { self.buf[self.off].assume_init() } == b'-';
-        (if sign {
-            self.off += 1;
-            self.noskip_u128().wrapping_neg()
-        } else {
-            self.noskip_u128()
-        }) as i128
-    }
-    fn u128(&mut self) -> u128 {
-        self.skip_whitespace();
-        self.try_refill(40);
-        self.noskip_u128()
-    }
-    #[cfg(target_pointer_width = "32")]
-    fn isize(&mut self) -> isize {
-        self.i32() as isize
-    }
-    #[cfg(target_pointer_width = "32")]
-    fn usize(&mut self) -> usize {
-        self.u32() as usize
-    }
-    #[cfg(target_pointer_width = "64")]
-    fn isize(&mut self) -> isize {
-        self.i64() as isize
-    }
-    #[cfg(target_pointer_width = "64")]
-    fn usize(&mut self) -> usize {
-        self.u64() as usize
-    }
-    #[cfg(all(not(target_pointer_width = "32"), not(target_pointer_width = "64")))]
-    fn isize(&mut self) -> isize {
-        self.i128() as isize
-    }
-    #[cfg(all(not(target_pointer_width = "32"), not(target_pointer_width = "64")))]
-    fn usize(&mut self) -> usize {
-        self.u128() as usize
-    }
-    fn f64(&mut self) -> f64 {
-        /* For simplicity, we assume the input string is at most 64 bytes.
-         * Strings longer than this length are either incorrectly parsed
-         * (scientific notations get their exponents truncated) or approximately parsed
-         * (decimal notations get their tails truncated yielding approximately
-         * correct outputs). */
-        self.skip_whitespace();
-        self.try_refill(64);
-        let mut end = self.off;
-        while end < self.len && unsafe { self.buf[end].assume_init() } > b' ' {
-            end += 1;
-        }
-        if end == self.off {
-            f64::NAN
-        } else {
-            let s_u8 = unsafe { self.buf[self.off..end].assume_init_ref() };
-            let s = unsafe { core::str::from_utf8_unchecked(s_u8) };
-            let out = f64::from_str(s);
-            self.skip_until_whitespace();
-            if let Ok(ans) = out { ans } else { f64::NAN }
-        }
-    }
-    fn byte(&mut self) -> u8 {
-        self.try_refill(1);
-        let mut out = 0u8;
-        if self.off < self.len {
-            out = unsafe { self.buf[self.off].assume_init() };
-            self.off += 1;
-        }
-        out
-    }
-    // We do not use avx2 for this function since most of the time
-    // we only skip a few whitespaces.
-    fn skip_whitespace(&mut self) -> usize {
-        let mut len = 0;
-        'outer: loop {
-            while self.off < self.len {
-                if unsafe { self.buf[self.off].assume_init() } > b' ' {
-                    break 'outer len;
-                }
-                self.off += 1;
-                len += 1;
-            }
-            if self.try_refill(1) == 0 {
-                break len;
-            }
-        }
+    fn advance(&mut self, bytes: usize) {
+        self.off += bytes;
     }
 }
 

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -626,6 +626,15 @@ impl Default for MmapReader {
 #[cfg(all(target_arch = "x86_64", not(test)))]
 impl MmapReader {
     pub fn new() -> Self {
+        #[cfg(not(feature = "submit"))]
+        {
+            let pd = crate::platform::services::platform_data();
+            assert!(
+                pd.env_id == crate::platform::services::ENV_ID_LINUX,
+                "MmapReader is only supported on Linux x64"
+            );
+        }
+
         let mut st = [0u32; 100];
         unsafe {
             crate::platform::os::linux::syscall::syscall3(5, 0, st.as_mut_ptr() as usize, 0);

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -378,7 +378,11 @@ impl<T: ReaderBufferTrait> ReaderTrait for T {
     fn i64(&mut self) -> i64 {
         self.skip_whitespace();
         self.try_refill(25);
-        let sign = self.remain()[0] == b'-';
+        let sign = unsafe {
+            self.remain_internal()
+                .as_ptr()
+                .read_unaligned()
+        } == b'-';
         (if sign {
             self.advance(1);
             self.noskip_u64().wrapping_neg()

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -585,13 +585,13 @@ impl Default for MmapReader {
 #[cfg(all(target_arch = "x86_64", not(test)))]
 impl MmapReader {
     pub fn new() -> Self {
-        let st = [0u32; 100];
-        unsafe {
-            crate::platform::os::linux::syscall::syscall3(5, 0, st.as_ptr() as usize, 0);
-        }
+        let mut st = [0u32; 100];
+        unsafe { crate::platform::os::linux::syscall::syscall3(5, 0, st.as_mut_ptr() as usize, 0); }
         let st_size = st[12] as usize;
         let buf = unsafe {
-            crate::platform::os::linux::syscall::mmap(core::ptr::null(), st_size, 1, 1, 0, 0)
+            // the +8 is for providing extra buffer that is safe to read for noskip_u64 and other functions
+            // (which enables accelerated parsing)
+            crate::platform::os::linux::syscall::mmap(core::ptr::null(), st_size + 8, 1, 1, 0, 0)
         };
         Self {
             buf,

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -576,7 +576,7 @@ impl<const N: usize> ReaderBufferTrait for Reader<N> {
     }
 }
 
-#[allow(dead_code)]
+#[cfg(all(target_arch = "x86_64", not(test)))]
 pub struct MmapReader {
     buf: *const u8,
     len: usize,

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -273,12 +273,12 @@ impl<T: ReaderBufferTrait> ReaderTrait for T {
             let rem = core::cmp::min(len, buf.len() - total);
             let data = &range[..rem];
             if let Some(pos) = unsafe { position::white(data) } {
-                buf[len..len + pos].copy_from_slice(&data[..pos]);
+                buf[total..total + pos].copy_from_slice(&data[..pos]);
                 total += pos;
                 self.advance(pos);
                 break;
             } else {
-                buf[len..len + rem].copy_from_slice(data);
+                buf[total..total + rem].copy_from_slice(data);
                 total += rem;
                 self.advance(rem);
                 self.try_refill(1);

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -77,6 +77,10 @@ trait ReaderBufferTrait: Sized {
         let mut n = 0;
         'outer: loop {
             let data = self.remain();
+            if data.is_empty() {
+                // no more data available
+                break n;
+            }
             for i in 0..data.len() {
                 let b = data[i];
                 if b > 32 {
@@ -94,6 +98,10 @@ trait ReaderBufferTrait: Sized {
         let mut n = 0;
         'outer: loop {
             let data = self.remain();
+            if data.is_empty() {
+                // no more data available
+                break n;
+            }
             for (i, &b) in data.iter().enumerate() {
                 if b > 32 {
                     n *= 10;

--- a/basm-std/src/platform/io/reader.rs
+++ b/basm-std/src/platform/io/reader.rs
@@ -378,11 +378,7 @@ impl<T: ReaderBufferTrait> ReaderTrait for T {
     fn i64(&mut self) -> i64 {
         self.skip_whitespace();
         self.try_refill(25);
-        let sign = unsafe {
-            self.remain_internal()
-                .as_ptr()
-                .read_unaligned()
-        } == b'-';
+        let sign = unsafe { self.remain_internal().as_ptr().read_unaligned() } == b'-';
         (if sign {
             self.advance(1);
             self.noskip_u64().wrapping_neg()
@@ -590,7 +586,9 @@ impl Default for MmapReader {
 impl MmapReader {
     pub fn new() -> Self {
         let mut st = [0u32; 100];
-        unsafe { crate::platform::os::linux::syscall::syscall3(5, 0, st.as_mut_ptr() as usize, 0); }
+        unsafe {
+            crate::platform::os::linux::syscall::syscall3(5, 0, st.as_mut_ptr() as usize, 0);
+        }
         let st_size = st[12] as usize;
         let buf = unsafe {
             // the +8 is for providing extra buffer that is safe to read for noskip_u64 and other functions

--- a/basm-std/src/platform/os/linux.rs
+++ b/basm-std/src/platform/os/linux.rs
@@ -9,6 +9,7 @@ pub mod syscall {
 
     pub const PROT_READ: i32 = 0x01;
     pub const PROT_WRITE: i32 = 0x02;
+    pub const MAP_SHARED: i32 = 0x01;
     pub const MAP_PRIVATE: i32 = 0x02;
     pub const MAP_ANON: i32 = 0x20;
     pub const MREMAP_MAYMOVE: i32 = 0x01;
@@ -19,6 +20,7 @@ pub mod syscall {
     mod id_list {
         pub const READ: usize = 0;
         pub const WRITE: usize = 1;
+        pub const FSTAT: usize = 5;
         pub const MMAP: usize = 9;
         pub const MREMAP: usize = 25;
         pub const MUNMAP: usize = 11;
@@ -30,6 +32,7 @@ pub mod syscall {
     mod id_list {
         pub const READ: usize = 3;
         pub const WRITE: usize = 4;
+        //pub const FSTAT: usize = 108;
         pub const MMAP: usize = 90;
         pub const MREMAP: usize = 163;
         pub const MUNMAP: usize = 91;
@@ -41,6 +44,7 @@ pub mod syscall {
     mod id_list {
         pub const READ: usize = 63;
         pub const WRITE: usize = 64;
+        //pub const FSTAT: usize = 80;
         pub const MMAP: usize = 222;
         pub const MREMAP: usize = 216;
         pub const MUNMAP: usize = 215;
@@ -54,6 +58,30 @@ pub mod syscall {
     pub struct RLimit {
         pub rlim_cur: usize,
         pub rlim_max: usize,
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[derive(Default)]
+    #[repr(C, packed)]
+    pub struct Stat {
+        pub st_dev: u64,
+        pub st_ino: u64,
+        pub st_nlink: u64,
+        pub st_mode: u32,
+        pub st_uid: u32,
+        pub st_gid: u32,
+        pad1: u32,
+        pub st_rdev: u64,
+        pub st_size: u64,
+        pub st_blksize: u64,
+        pub st_blocks: u64,
+        pub st_atime: u64,
+        pad2: u64,
+        pub st_mtime: u64,
+        pad3: u64,
+        pub st_ctime: u64,
+        pad4: u64,
+        pad5: [u8; 32],
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -329,6 +357,10 @@ pub mod syscall {
                 0,
             )
         }
+    }
+    #[cfg(target_arch = "x86_64")]
+    pub unsafe fn fstat(fd: usize, st: &mut Stat) -> usize {
+        unsafe { syscall3(id_list::FSTAT, fd, st as *mut Stat as usize, 0) }
     }
 }
 

--- a/scripts/build-and-judge.py
+++ b/scripts/build-and-judge.py
@@ -49,6 +49,7 @@ if __name__ == '__main__':
     os.makedirs(tmp_dir, exist_ok=True)
     src_path = os.path.abspath(os.path.join(tmp_dir, "output.{0}".format(src_ext)))
     bin_path = os.path.abspath(os.path.join(tmp_dir, "loader.exe" if platform.system() == "Windows" else "loader"))
+    sol_backup_path = os.path.abspath(os.path.join(tmp_dir, "solution_old.rs"))
     try_remove(src_path)
     try_remove(bin_path)
 
@@ -70,7 +71,7 @@ if __name__ == '__main__':
 
     # Replace the solution
     shutil.copyfile(sol_path, "basm/src/solution_new.rs")
-    os.rename("basm/src/solution.rs", "basm/src/solution_old.rs")
+    os.rename("basm/src/solution.rs", sol_backup_path)
     os.rename("basm/src/solution_new.rs", "basm/src/solution.rs")
 
     # Build the project to generate the source code
@@ -97,7 +98,7 @@ if __name__ == '__main__':
     finally:
         # Restore the original solution
         try_remove("basm/src/solution.rs")
-        os.rename("basm/src/solution_old.rs", "basm/src/solution.rs")
+        os.rename(sol_backup_path, "basm/src/solution.rs")
 
     # Compile the source code
     run_cmd = [bin_path]

--- a/tests/boj_2751_mmapreader.rs
+++ b/tests/boj_2751_mmapreader.rs
@@ -1,0 +1,14 @@
+use basm::platform::io::{MmapReader, ReaderTrait, Writer, Print};
+use alloc::collections::BTreeSet;
+pub fn main() {
+    let mut reader = MmapReader::new();
+    let mut writer: Writer = Default::default();
+    let mut s = BTreeSet::new();
+    let n = reader.usize();
+    for _ in 0..n {
+        s.insert(reader.i32());
+    }
+    for x in s {
+        writer.println(x);
+    }
+}

--- a/tests/ci.json
+++ b/tests/ci.json
@@ -20,6 +20,23 @@
         "output": "./tests/boj_2751.out.zip"
     },
     {
+        "solution": "./tests/boj_2751_mmapreader.rs",
+        "input": "./tests/boj_2751.in.zip",
+        "output": "./tests/boj_2751.out.zip",
+        "target_platforms": [
+            {
+                "os": "Linux",
+                "language": "C",
+                "bits": "64"
+            },
+            {
+                "os": "Linux",
+                "language": "Rust",
+                "bits": "64"
+            }
+        ]
+    },
+    {
         "solution": "./tests/boj_3745.rs",
         "input": "./tests/boj_3745.in",
         "output": "./tests/boj_3745.out"


### PR DESCRIPTION
* 기존 Reader 구현을 버퍼와 파싱으로 분리하고 버퍼를 ReaderBufferTrait으로 분리하였습니다.
* MmapReader를 추가하여 빠른 입력을 가능하게 합니다.
* MockReader를 추가하여 파싱 루틴의 유닛 테스트를 활성화하였습니다.
* MmapReader를 Linux x64에서만 테스트하기 위해 CI 부분을 수정했습니다. MmapReader에 대한 새 테스트가 추가되었습니다(`tests/boj_2751_mmapreader.rs`).

Fixes #118.